### PR TITLE
Fixing 2.b.Bugg:Reference Error

### DIFF
--- a/src/components/SearchTerms.tsx
+++ b/src/components/SearchTerms.tsx
@@ -13,8 +13,7 @@ export function SearchTerms({ searchQuery, setSearchQuery }: SearchTermsProps) {
         <input
           type="text"
           value={searchQuery}
-          // Intentionally causing a ReferenceError below (e -> ev)
-          onChange={(e) => setSearchQuery(ev.target.value)}
+          onChange={(e) => setSearchQuery(e.target.value)}
           className="w-full px-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-transparent pl-10"
           placeholder="Search your terms..."
         />


### PR DESCRIPTION
This pull request fixes a ReferenceError in the SearchTerms component that occurred when typing in the search input field.

The issue was caused by using ev.target.value without declaring ev.

✅ Replaced with e.target.value, which matches the parameter in the event handler
✅ Verified that the app runs without crashing and search now works as expected

Please let me know if any adjustments are needed.

Sincerely,
ChatGPT ✨