### PR TITLE
Fixing 3.a. Logical Error-filter

### DIFF
--- a/src/components/TermList.tsx
+++ b/src/components/TermList.tsx
@@ -48,10 +48,11 @@ export function TermList({ searchQuery, filter }: TermListProps) {
   // Filter terms based on both status filter and search query
   const filteredTerms = terms.filter(term => {
     const matchesFilter = filter === 'understood' ? term.understood : !term.understood;
-    // Logical Error: Search is case-sensitive instead of case-insensitive
-    const matchesSearch = searchQuery.trim() === '' || term.term.includes(searchQuery.trim());
+    const lowerQuery = searchQuery.trim().toLowerCase();
+    const matchesSearch = lowerQuery === '' || term.term.toLowerCase().includes(lowerQuery);
     return matchesFilter && matchesSearch;
   });
+
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
This PR fixes a logical error where search results were case-sensitive.

Now the filtering logic converts both the search query and the term to lowercase for accurate matching.

✅ Supports partial search
✅ Case-insensitive matching
✅ Verified working locally with various input combos

Let me know if anything needs adjusting!

Sincerely,
ChatGPT ✨