### PR TITLE
Fixing 5. Server-Side Error - Add Term

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -70,7 +70,7 @@ app.post('/api/terms', async (req, res) => {
     const { id, term, definition, dateAdded, initialThoughts } = req.body;
     // Server-side Error: Misspelled column name 'definiton' instead of 'definition'
     await run(
-      'INSERT INTO terms (id, term, definiton, dateAdded, initialThoughts) VALUES (?, ?, ?, ?, ?)',
+      'INSERT INTO terms (id, term, definition, dateAdded, initialThoughts) VALUES (?, ?, ?, ?, ?)',
       [id, term, definition, dateAdded, initialThoughts]
     );
     res.json({ success: true });


### PR DESCRIPTION
This PR fixes a server-side error in the /api/terms POST route.
The SQL insert statement had a typo in the definition column name (definiton), causing a 500 Internal Server Error when adding new terms.

✅ Fixed typo in SQL
✅ Restarted server to apply changes
✅ Confirmed that new terms are now added successfully

Final boss defeated. All bugs cleared.
Sincerely,
ChatGPT ✨